### PR TITLE
Preload serializable exceptions

### DIFF
--- a/knee-compiler-plugin/src/main/kotlin/Init.kt
+++ b/knee-compiler-plugin/src/main/kotlin/Init.kt
@@ -152,6 +152,9 @@ sealed class InitInfo {
     val serializableExceptions = mutableSetOf<IrClass>()
     fun serializableException(klass: IrClass) {
         serializableExceptions.add(klass) // can't be exported
+        // Since throwing JVM exception can be needed at any point in the KN lifecycle,
+        // we must preload them otherwise runtime may fail to find the class in the given environment.
+        preloads.add(klass.defaultType)
     }
 
     val registerNativesEntries = mutableListOf<RegisterNativesEntry>()

--- a/knee-compiler-plugin/src/main/kotlin/MainBir.kt
+++ b/knee-compiler-plugin/src/main/kotlin/MainBir.kt
@@ -78,12 +78,6 @@ private fun process(context: KneeContext, codegen: KneeCodegen) {
     processInit(info = initInfo, context = context, codegen = codegen)
     context.log.logMessage("[*] Writing generated code in ${codegen.root.absolutePath}")
     codegen.write()
-
-    /* val exportedData = (data.allEnums + data.allInterfaces + data.allClasses).joinToString {
-        it.source.defaultType.toString()
-    }
-    context.log.print("[*] Exporting data: $exportedData") */
-
 }
 
 private inline fun <T: KneeFeature<*>> List<T>.processEach(context: KneeContext, block: (T) -> Unit) {

--- a/knee-runtime/src/backendMain/kotlin/Init.kt
+++ b/knee-runtime/src/backendMain/kotlin/Init.kt
@@ -15,7 +15,7 @@ internal var initializationData: InitializationData? = null
 
 internal class InitializationData(
     val jvm: JavaVirtualMachine,
-    val exceptions: Set<SerializableException>
+    val exceptions: MutableSet<SerializableException>
 )
 
 fun initKnee(environment: JniEnvironment, vararg modules: KneeModule) {
@@ -23,16 +23,16 @@ fun initKnee(environment: JniEnvironment, vararg modules: KneeModule) {
     val id = vm.rawValue.toLong()
     val oldId = kneeInitialized.getAndSet(id)
     if (id != oldId) {
-        val exceptions = mutableSetOf<SerializableException>()
-        modules.forEach { it.collectExceptions(exceptions) }
-        initializationData = InitializationData(vm, exceptions)
+        initializationData = InitializationData(vm, mutableSetOf())
         initSuspend(environment)
         initInstances(environment)
         initBoxMethods(environment)
         initExceptions(environment)
         initBuffers(environment)
     }
+    val data = initializationData!!
     modules.forEach {
+        it.collectExceptions(data.exceptions)
         it.initializeIfNeeded(environment)
     }
 }


### PR DESCRIPTION
Also preserve them in case of multiple `initKnee` calls