### PR TITLE
Support empty strings in default values

### DIFF
--- a/knee-compiler-plugin/src/main/kotlin/utils/PoetUtils.kt
+++ b/knee-compiler-plugin/src/main/kotlin/utils/PoetUtils.kt
@@ -203,7 +203,7 @@ fun IrValueParameter.defaultValueForCodegen(functionExpects: List<IrDeclarationW
     if (expression is IrConst<*>) {
         return when (val kind = expression.kind) {
             is IrConstKind.Null -> CodeBlock.of("null")
-            is IrConstKind.String -> CodeBlock.of(kind.valueOf(expression))
+            is IrConstKind.String -> CodeBlock.of("%S", kind.valueOf(expression))
             else -> CodeBlock.of("%L", kind.valueOf(expression))
             // is IrConstKind.Boolean -> CodeBlock.of(kind.valueOf(expression).toString())
             // is IrConstKind.Int -> CodeBlock.of(kind.valueOf(expression).toString())

--- a/tests/test-misc/src/androidInstrumentedTest/kotlin/io/deepmedia/tools/knee/tests/DefaultValuesTests.kt
+++ b/tests/test-misc/src/androidInstrumentedTest/kotlin/io/deepmedia/tools/knee/tests/DefaultValuesTests.kt
@@ -21,4 +21,9 @@ class DefaultValuesTests {
         ConcreteClassWithDefaultValues().withNull()
     }
 
+    @Test
+    fun testDefaultValue_emptyString() {
+        emptyStringDefaultValue()
+    }
+
 }

--- a/tests/test-misc/src/backendMain/kotlin/DefaultValuesDefinitions.kt
+++ b/tests/test-misc/src/backendMain/kotlin/DefaultValuesDefinitions.kt
@@ -19,3 +19,7 @@ interface BaseInterfaceWithDefaultValues {
 
     }
 }
+
+@Knee
+fun emptyStringDefaultValue(foo: String = "") {
+}


### PR DESCRIPTION
Fixes an issue where default arguments declared as `""` would cause invalid code generation.