### PR TITLE
Nested collections support

### DIFF
--- a/docs/features/builtin-types.mdx
+++ b/docs/features/builtin-types.mdx
@@ -60,7 +60,10 @@ For example, since `Int` is serializable, Knee can also serialize:
 - `List<Int>`
 - `Set<Int>`
 
-As you may, the performance of these options is not the same because the `IntArray` signature avoids boxing.
+As you may know, the performance of these options is not the same because the `IntArray` signature avoids boxing.
 
 > In case of non-primitive values, `Array<Type>` will be used. That may still perform better than `List` or `Set`,
 > although not dramatically better.
+
+Note that since you can serialize collections of any serializable type, and collections themselves are serializable,
+nested types are supported. For example, you may pass things like `List<Set<Float>>`, `Set<IntArray>` or `Array<Array<MyObject>>`.

--- a/knee-compiler-plugin/src/main/kotlin/DownwardFunctions.kt
+++ b/knee-compiler-plugin/src/main/kotlin/DownwardFunctions.kt
@@ -234,7 +234,6 @@ private fun KneeDownwardFunction.makeIr(context: KneeContext, signature: Downwar
                                     +when (val type = signature.result.encodedType) {
                                         is JniType.Void -> irUnit()
                                         is JniType.Object -> irNull()
-                                        is JniType.Array -> irNull()
                                         is JniType.Int -> irInt(0)
                                         is JniType.Long -> irLong(0)
                                         is JniType.Float -> IrConstImpl.float(startOffset, endOffset, type.kn, 0F)

--- a/knee-compiler-plugin/src/main/kotlin/codec/GenericCodec.kt
+++ b/knee-compiler-plugin/src/main/kotlin/codec/GenericCodec.kt
@@ -47,7 +47,6 @@ class GenericCodec(
 
         return when (wrappedType) {
             is JniType.Object -> data // already a jobject
-            is JniType.Array -> data // already a jobject
             is JniType.Long -> irEncodeBoxed("Long")
             is JniType.Int -> irEncodeBoxed("Int")
             is JniType.Double -> irEncodeBoxed("Double")
@@ -66,7 +65,6 @@ class GenericCodec(
 
         val decoded = when (wrappedType) {
             is JniType.Object -> irGet(jni) // irAs(irGet(jni), wrappedType.kn)
-            is JniType.Array -> irGet(jni) // irAs(irGet(jni), wrappedType.kn)
             is JniType.Long -> irDecodeBoxed("Long")
             is JniType.Int -> irDecodeBoxed("Int")
             is JniType.Double -> irDecodeBoxed("Double")

--- a/knee-compiler-plugin/src/main/kotlin/functions/UpwardFunctionsIr.kt
+++ b/knee-compiler-plugin/src/main/kotlin/functions/UpwardFunctionsIr.kt
@@ -73,7 +73,7 @@ object UpwardFunctionsIr {
     private val JniType.nameOfCallMethodFunction: String get() {
         return when (this) {
             is JniType.Void -> "Void"
-            is JniType.Object, is JniType.Array -> "Object"
+            is JniType.Object -> "Object"
             is JniType.Int -> "Int"
             is JniType.BooleanAsUByte -> "Boolean"
             is JniType.Float -> "Float"

--- a/knee-compiler-plugin/src/main/kotlin/jni/JniSignature.kt
+++ b/knee-compiler-plugin/src/main/kotlin/jni/JniSignature.kt
@@ -47,16 +47,16 @@ object JniSignature {
             is JniType.Double -> append('D')
 
             // OBJECT TYPES
-            is JniType.Object -> {
-                append('L')
-                append(type.jvm.jvmClassName) // cares about dollar signs
-                append(';')
-            }
-
-            // ARRAY TYPES
-            is JniType.Array -> {
-                append("[")
-                appendJniType(type.element, isReturnType)
+            is JniType.Object -> when (val arrayElement = type.arrayElement) {
+                null -> {
+                    append('L')
+                    append(type.jvm.jvmClassName) // cares about dollar signs
+                    append(';')
+                }
+                else -> {
+                    append("[")
+                    appendJniType(arrayElement, isReturnType)
+                }
             }
         }
     }


### PR DESCRIPTION
Previously we'd file at things like `List<List<Type>>`, which, for example, also prevents exposing `SharedFlow<List<Type>>` because of the replay cache.